### PR TITLE
added logger for ease of development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,53 @@
 # MmdOS
 
 ### Overview
+
 A 64-bit higher half kernel OS
 
 ## Installation
-You need an [GCC compiler](https://gcc.gnu.org/), [ld linker](https://www.gnu.org/software/binutils/) 
-which are usually pre-installed on UNIX-like systems. Also [qemu](https://www.qemu.org/) and [nasm](https://www.nasm.us/) 
-[xorriso](https://www.gnu.org/software/xorriso/) must be available. 
+
+You need an [GCC compiler](https://gcc.gnu.org/), [ld linker](https://www.gnu.org/software/binutils/)
+which are usually pre-installed on UNIX-like systems. Also [qemu](https://www.qemu.org/), [nasm](https://www.nasm.us/),
+[xorriso](https://www.gnu.org/software/xorriso/) and [make](https://www.gnu.org/software/make/) must be available.
+
 Then run:
+
 ```sh
 make
+```
+
+to compile and build in debug mode or run:
+
+```sh
+make prod
+```
+
+to compile and build in production mode.
+
+then execute:
+
+```sh
 make run
 ```
-which will build, run and clean.
+
+if you want to run the os using qemu.
 
 #### Implemented features
-| Feature | State |
-| ------- | -------|
+
+| Feature           | State |
+| ----------------- | ----- |
 | Limine bootloader | works |
-| kernel loading | works |
-| GDT | works |
-| IDT | works |
-| PIC | works |
-| PIT | works |
-| Keyboard | works |
-| printf | works |
+| kernel loading    | works |
+| GDT               | works |
+| IDT               | works |
+| PIC               | works |
+| PIT               | works |
+| Keyboard          | works |
+| printf            | works |
 
 #### TODO for the forseeable future
-*** In the future, rewrite the assignment to registers and etc. using Unions ***
+
+**_ In the future, rewrite the assignment to registers and etc. using Unions _**
 | Feature to be implemented |
 | ------- |
 | Video Output |
@@ -36,8 +56,9 @@ which will build, run and clean.
 | Definition for CPUs and saving state |
 
 #### Description
-The `C` files and potential `asm` files are compiled into object files in the `bin` 
-directory and then will be linked by the linker `ld` and the `linker.ld` script with 
-appropriate flags and the linked result will be put in `disk` directory. here the `iso` 
-will be created and `limine` will be installed on it and the result of the process would 
+
+The `C` files and potential `asm` files are compiled into object files in the `bin`
+directory and then will be linked by the linker `ld` and the `linker.ld` script with
+appropriate flags and the linked result will be put in `disk` directory. here the `iso`
+will be created and `limine` will be installed on it and the result of the process would
 be a bootable `iso`.

--- a/src/kernel/formatter.c
+++ b/src/kernel/formatter.c
@@ -1,0 +1,148 @@
+#include "formatter.h"
+#include <stdint.h>
+
+void int_to_hex(uint64_t i, char *buffer) {
+    char hex_chars[16] = "0123456789abcdef";
+    uint64_t num = i;
+    uint8_t rem = 0;
+
+    uint64_t index = 0;
+
+    while (num != 0 && index < MAX_HEX_HANDLER_BUFFER_SIZE) {
+        rem = num % 16;
+        num /= 16;
+        buffer[index] = hex_chars[rem];
+        index++;
+    }
+
+    uint32_t k = 0;
+    uint32_t j = index - 1;
+    while (k < j) {
+        char temp = buffer[k];
+        buffer[k] = buffer[j];
+        buffer[j] = temp;
+        k++;
+        j--;
+    }
+
+    return;
+}
+
+int format_string(char *s, char buffer[], int buffer_offset) {
+    while (*s && buffer_offset < MAX_STRING_FORMATTER_BUFFER_SIZE) {
+        buffer[buffer_offset] = *s;
+        buffer_offset++;
+        s++;
+    }
+    return buffer_offset;
+}
+
+int format_char(int c, char buffer[], int buffer_offset) {
+    if (buffer_offset < MAX_STRING_FORMATTER_BUFFER_SIZE) {
+        buffer[buffer_offset] = c;
+        buffer_offset++;
+    }
+    return buffer_offset;
+}
+
+int format_int(int64_t integer, char buffer[], int buffer_offset) {
+    uint32_t len = 0;
+    int64_t remainder = integer;
+    while (remainder != 0) {
+        len++;
+        remainder /= 10;
+    }
+
+    char number[len];
+
+    for (uint32_t i = 0; i < len; i++) {
+        number[i] = (integer % 10) + '0';
+        integer /= 10;
+    }
+
+    for (int i = len - 1; i >= 0; i--) {
+        if (buffer_offset < MAX_STRING_FORMATTER_BUFFER_SIZE) {
+            buffer[buffer_offset] = number[i];
+            buffer_offset++;
+        } else {
+            break;
+        }
+    }
+
+    return buffer_offset;
+}
+
+int format_hex(uint64_t hex_int, char buffer[], int buffer_offset) {
+    char hex_string[MAX_HEX_HANDLER_BUFFER_SIZE] = {0};
+    int_to_hex(hex_int, hex_string);
+    return format_string(hex_string, buffer, buffer_offset);
+}
+
+int format_handler(char format, char buffer[], int buffer_offset,
+                   va_list args) {
+    switch (format) {
+    // digit/int
+    case 'd':
+    case 'i':
+        int64_t int_arg = va_arg(args, int64_t);
+        buffer_offset = format_int(int_arg, buffer, buffer_offset);
+        break;
+
+    // unsigned int
+    case 'u':
+        break;
+
+    // unsigned octal
+    case 'o':
+        break;
+
+    // unsigned hexadecimal
+    case 'X':
+    // parse to lowercase
+    case 'p':
+    case 'x':
+        if (buffer_offset + 2 < MAX_STRING_FORMATTER_BUFFER_SIZE) {
+            buffer[buffer_offset] = '0';
+            buffer[buffer_offset + 1] = 'x';
+            buffer_offset += 2;
+            uint64_t hex_arg = va_arg(args, uint64_t);
+            buffer_offset = format_hex(hex_arg, buffer, buffer_offset);
+        }
+        break;
+
+    // decimal floating point
+    case 'F':
+    case 'f':
+        break;
+
+    // scietific notation
+    case 'E':
+    case 'e':
+        break;
+
+    // I don't even know
+    case 'G':
+    case 'g':
+        break;
+
+    // hexadecimal floating point
+    case 'A':
+    case 'a':
+        break;
+
+    // char
+    case 'c':
+        int arg_char = va_arg(args, int);
+        buffer_offset = format_char(arg_char, buffer, buffer_offset);
+        break;
+
+    // string
+    case 's':
+        char *arg_str = va_arg(args, char *);
+        buffer_offset = format_string(arg_str, buffer, buffer_offset);
+        break;
+    default:
+        break;
+    }
+    return buffer_offset;
+}

--- a/src/kernel/formatter.h
+++ b/src/kernel/formatter.h
@@ -1,0 +1,11 @@
+#ifndef STRING_FORMATTER_DEF
+#define STRING_FORMATTER_DEF
+
+#include <stdarg.h>
+
+#define MAX_STRING_FORMATTER_BUFFER_SIZE 1024
+#define MAX_HEX_HANDLER_BUFFER_SIZE 64
+
+int format_handler(char format, char buffer[], int buffer_offset, va_list args);
+
+#endif

--- a/src/kernel/formatter.h
+++ b/src/kernel/formatter.h
@@ -7,5 +7,5 @@
 #define MAX_HEX_HANDLER_BUFFER_SIZE 64
 
 int format_handler(char format, char buffer[], int buffer_offset, va_list args);
-
+int format_string(char *s, char buffer[], int buffer_offset);
 #endif

--- a/src/kernel/keyboard.c
+++ b/src/kernel/keyboard.c
@@ -109,8 +109,8 @@ interrupt_frame *keyboard_handler(interrupt_frame *frame) {
     case 28: // enter
         if (pressed == 0) {
             prompt_enter_handler();
-            printf("\n$: ");
-                }
+            kprintf("\n$: ");
+        }
         break;
     case 29: // ctrl
         break;
@@ -159,15 +159,15 @@ interrupt_frame *keyboard_handler(interrupt_frame *frame) {
 
             if (keyboard.shift && keyboard.caps_lock) {
                 // print lower case
-                printf("%c", lower_case[scancode]);
+                kprintf("%c", lower_case[scancode]);
                 prompt_char_handler(lower_case[scancode]);
             } else if (keyboard.shift || keyboard.caps_lock) {
                 // print upper case
-                printf("%c", upper_case[scancode]);
+                kprintf("%c", upper_case[scancode]);
                 prompt_char_handler(upper_case[scancode]);
             } else {
                 // print lower case
-                printf("%c", lower_case[scancode]);
+                kprintf("%c", lower_case[scancode]);
                 prompt_char_handler(lower_case[scancode]);
             }
         }

--- a/src/kernel/logger.c
+++ b/src/kernel/logger.c
@@ -1,0 +1,46 @@
+#include "logger.h"
+#include "cpu.h"
+#include "formatter.h"
+#include <stdarg.h>
+#include <stdint.h>
+
+void klog(const char *new_prefix, const char *fmt, ...) {
+    // loading optional parameters
+    va_list args;
+    va_start(args, fmt);
+
+    vklog(new_prefix, fmt, args);
+
+    va_end(args);
+}
+
+void vklog(const char *new_prefix, const char *fmt, va_list args) {
+    char buffer[MAX_STRING_FORMATTER_BUFFER_SIZE] = {0};
+
+    if (new_prefix != 0) {
+        int i = 0;
+        while (*new_prefix != '\0' && i < LOGGER_PREFIX_LENGTH - 2) {
+            prefix[i] = *new_prefix;
+            new_prefix++;
+            i++;
+        }
+        prefix[i] = ' ';
+        i++;
+        prefix[i] = '\0';
+    }
+
+    int i = format_string(prefix, buffer, 0);
+    while (*fmt && i < MAX_STRING_FORMATTER_BUFFER_SIZE) {
+        if (*fmt == '%') {
+            fmt++;
+            i = format_handler(*fmt, buffer, i, args);
+            fmt++;
+            continue;
+        }
+        buffer[i] = *fmt;
+        i++;
+
+        fmt++;
+    }
+    log_to_serial(buffer);
+}

--- a/src/kernel/logger.c
+++ b/src/kernel/logger.c
@@ -8,8 +8,9 @@ void klog(const char *new_prefix, const char *fmt, ...) {
     // loading optional parameters
     va_list args;
     va_start(args, fmt);
-
-    vklog(new_prefix, fmt, args);
+    if (!PROD_MODE) {
+        vklog(new_prefix, fmt, args);
+    }
 
     va_end(args);
 }

--- a/src/kernel/logger.h
+++ b/src/kernel/logger.h
@@ -1,0 +1,16 @@
+#ifndef KERNEL_LOGGER_DEF
+#define KERNEL_LOGGER_DEF
+
+#include <stdarg.h>
+
+#define LOGGER_PREFIX_LENGTH 32
+
+static char prefix[LOGGER_PREFIX_LENGTH] = {0};
+
+// kernel log: load args, then call virtual kernel log (vklog)
+void klog(const char *prefix, const char *fmt, ...);
+
+// virtual kernel log: format and then log to console
+void vklog(const char *prefix, const char *fmt, va_list args);
+
+#endif

--- a/src/kernel/panic.c
+++ b/src/kernel/panic.c
@@ -6,7 +6,7 @@ void panic(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
-    kernel_printf(fmt, args);
+    vkprintf(fmt, args);
 
     va_end(args);
 

--- a/src/kernel/pmm.c
+++ b/src/kernel/pmm.c
@@ -1,8 +1,8 @@
 #include "bitmap.h"
 #include "cpu.h"
 #include "limine.h"
+#include "logger.h"
 #include "panic.h"
-#include "print.h"
 #include "spinlock.h"
 #include "util.h"
 #include <stdint.h>
@@ -39,8 +39,8 @@ void pmm_init() {
 
         /* For some reason, entry->Type seems to be NULL */
 
-        kprintf("addr: %x, size: %d\n", entry->base, entry->length,
-                entry->type);
+        klog(0, "addr: %x, size: %d\n", entry->base, entry->length,
+             entry->type);
         // if(entry->type != 1) continue;
         switch (entry->type) {
         case LIMINE_MEMMAP_USABLE:
@@ -63,8 +63,8 @@ void pmm_init() {
     // uint64_t bitmap_size = div_round_up(page_index_limit , 8); // becaue we
     // use 1 bit per page
 
-    kprintf("pmm: highest addr: %x\n", highest_addr);
-    kprintf("pmm: bitmap size: %d\n", bitmap_size);
+    klog(0, "pmm: highest addr: %x\n", highest_addr);
+    klog(0, "pmm: bitmap size: %d\n", bitmap_size);
 
     // Find a hole for the bitmap in the memory map.
     // Find a place for the bitmap to reside in.
@@ -113,10 +113,10 @@ void pmm_init() {
         }
     }
 
-    kprintf("pmm: usable memory: %d Mib\n",
-            (usable_pages * PAGE_SIZE) / 1024 / 1024);
+    klog(0, "pmm: usable memory: %d Mib\n",
+         (usable_pages * PAGE_SIZE) / 1024 / 1024);
 
-    kprintf("pmm: Base Address: %x\n", base_addr);
+    klog(0, "pmm: Base Address: %x\n", base_addr);
 }
 
 void *physical_alloc(uint64_t n_pages, uint64_t limit) {
@@ -168,10 +168,10 @@ void *pmm_alloc(uint64_t n_pages) {
 
     spinlock_release(&spin_lock);
 
-    kprintf("pmm: allocated %d pages\n", n_pages);
-    kprintf("pmm: used memory: %d MiB\n",
-            (used_pages * PAGE_SIZE) / 1024 / 1024);
-    // kprintf("pmm: remaining memory: %d MiB\n", (usable_pages * PAGE_SIZE) /
+    klog(0, "pmm: allocated %d pages\n", n_pages);
+    klog(0, "pmm: used memory: %d MiB\n",
+         (used_pages * PAGE_SIZE) / 1024 / 1024);
+    // klog(0,"pmm: remaining memory: %d MiB\n", (usable_pages * PAGE_SIZE) /
     // 1024 / 1024);
 
     return allocated;

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -4,17 +4,17 @@
 #include "stdint.h"
 #include <stdarg.h>
 
-void printf(const char *fmt, ...) {
+void kprintf(const char *fmt, ...) {
     // loading optional parameters
     va_list args;
     va_start(args, fmt);
 
-    kernel_printf(fmt, args);
+    vkprintf(fmt, args);
 
     va_end(args);
 }
 
-void kernel_printf(const char *fmt, va_list args) {
+void vkprintf(const char *fmt, va_list args) {
     char buffer[MAX_STRING_FORMATTER_BUFFER_SIZE] = {0};
 
     int i = 0;

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -1,150 +1,8 @@
 #include "print.h"
+#include "formatter.h"
 #include "limine_term.h"
 #include "stdint.h"
 #include <stdarg.h>
-
-void int_to_hex(uint64_t i, char *buffer, int32_t buffer_size) {
-    char hex_chars[16] = "0123456789abcdef";
-    uint64_t num = i;
-    uint8_t rem = 0;
-
-    uint64_t index = 0;
-
-    while (num != 0 && index < buffer_size) {
-        rem = num % 16;
-        num /= 16;
-        buffer[index] = hex_chars[rem];
-        index++;
-    }
-
-    uint32_t k = 0;
-    uint32_t j = index - 1;
-    while (k < j) {
-        char temp = buffer[k];
-        buffer[k] = buffer[j];
-        buffer[j] = temp;
-        k++;
-        j--;
-    }
-
-    return;
-}
-
-int format_string(char *s, char buffer[], int buffer_offset) {
-    while (*s && buffer_offset < MAX_PRINTF_BUFFER_SIZE) {
-        buffer[buffer_offset] = *s;
-        buffer_offset++;
-        s++;
-    }
-    return buffer_offset;
-}
-
-int format_char(int c, char buffer[], int buffer_offset) {
-    if (buffer_offset < MAX_PRINTF_BUFFER_SIZE) {
-        buffer[buffer_offset] = c;
-        buffer_offset++;
-    }
-    return buffer_offset;
-}
-
-int format_int(int64_t integer, char buffer[], int buffer_offset) {
-    uint32_t len = 0;
-    int64_t remainder = integer;
-    while (remainder != 0) {
-        len++;
-        remainder /= 10;
-    }
-
-    char number[len];
-
-    for (uint32_t i = 0; i < len; i++) {
-        number[i] = (integer % 10) + '0';
-        integer /= 10;
-    }
-
-    for (int i = len - 1; i >= 0; i--) {
-        if (buffer_offset < MAX_PRINTF_BUFFER_SIZE) {
-            buffer[buffer_offset] = number[i];
-            buffer_offset++;
-        } else {
-            break;
-        }
-    }
-
-    return buffer_offset;
-}
-
-int format_hex(uint64_t hex_int, char buffer[], int buffer_offset) {
-    char hex_string[64] = {0};
-    int_to_hex(hex_int, hex_string, 64);
-    return format_string(hex_string, buffer, buffer_offset);
-}
-
-int format_handle(char format, char buffer[], int buffer_offset, va_list args) {
-    switch (format) {
-    // digit/int
-    case 'd':
-    case 'i':
-        int64_t int_arg = va_arg(args, int64_t);
-        buffer_offset = format_int(int_arg, buffer, buffer_offset);
-        break;
-
-    // unsigned int
-    case 'u':
-        break;
-
-    // unsigned octal
-    case 'o':
-        break;
-
-    // unsigned hexadecimal
-    case 'X':
-    // parse to lowercase
-    case 'p':
-    case 'x':
-        buffer[buffer_offset] = '0';
-        buffer[buffer_offset + 1] = 'x';
-        buffer_offset += 2;
-        uint64_t hex_arg = va_arg(args, uint64_t);
-        buffer_offset = format_hex(hex_arg, buffer, buffer_offset);
-        break;
-
-    // decimal floating point
-    case 'F':
-    case 'f':
-        break;
-
-    // scietific notation
-    case 'E':
-    case 'e':
-        break;
-
-    // I don't even know
-    case 'G':
-    case 'g':
-        break;
-
-    // hexadecimal floating point
-    case 'A':
-    case 'a':
-        break;
-
-    // char
-    case 'c':
-        int arg_char = va_arg(args, int);
-        buffer_offset = format_char(arg_char, buffer, buffer_offset);
-        break;
-
-    // string
-    case 's':
-        char *arg_str = va_arg(args, char *);
-        buffer_offset = format_string(arg_str, buffer, buffer_offset);
-        break;
-    default:
-        break;
-    }
-    return buffer_offset;
-}
 
 void printf(const char *fmt, ...) {
     // loading optional parameters
@@ -157,13 +15,13 @@ void printf(const char *fmt, ...) {
 }
 
 void kernel_printf(const char *fmt, va_list args) {
-    char buffer[MAX_PRINTF_BUFFER_SIZE] = {0};
+    char buffer[MAX_STRING_FORMATTER_BUFFER_SIZE] = {0};
 
     int i = 0;
-    while (*fmt && i < MAX_PRINTF_BUFFER_SIZE) {
+    while (*fmt && i < MAX_STRING_FORMATTER_BUFFER_SIZE) {
         if (*fmt == '%') {
             fmt++;
-            i = format_handle(*fmt, buffer, i, args);
+            i = format_handler(*fmt, buffer, i, args);
             fmt++;
             continue;
         }

--- a/src/kernel/print.h
+++ b/src/kernel/print.h
@@ -3,10 +3,10 @@
 
 #include <stdarg.h>
 
-// load args, then format and print
-void printf(const char *fmt, ...);
+// kernel printf: load args, then call virtual kernel printf (vkprintf)
+void kprintf(const char *fmt, ...);
 
-// format and print
-void kernel_printf(const char *fmt, va_list args);
+// virtual kernel printf: format and print
+void vkprintf(const char *fmt, va_list args);
 
 #endif

--- a/src/kernel/print.h
+++ b/src/kernel/print.h
@@ -3,8 +3,6 @@
 
 #include <stdarg.h>
 
-#define MAX_PRINTF_BUFFER_SIZE 1024
-
 // load args, then format and print
 void printf(const char *fmt, ...);
 

--- a/src/kernel/prompt.c
+++ b/src/kernel/prompt.c
@@ -6,14 +6,14 @@ void prompt_init() {
     for (int i = 0; i < PROMPT_BUFFER_SIZE; i++) {
         buffer[i] = '\0';
     }
-    printf("$: ");
+    kprintf("$: ");
 }
 
 void prompt_enter_handler() {
     if (line_len > 0) {
-        printf("\n");
+        kprintf("\n");
         line_num++;
-        printf("%s", buffer);
+        kprintf("%s", buffer);
     }
 
     for (int i = 0; buffer_pointer > 0; buffer_pointer--) {
@@ -38,5 +38,5 @@ void prompt_backspace_handler() {
     line_len--;
     buffer_pointer--;
     buffer[buffer_pointer] = '\0';
-    printf("\b \b");
+    kprintf("\b \b");
 }

--- a/src/kernel/startup.c
+++ b/src/kernel/startup.c
@@ -2,6 +2,7 @@
 #include "idt.h"
 #include "keyboard.h"
 #include "limine_term.h"
+#include "logger.h"
 #include "pic.h"
 #include "pmm.h"
 #include "print.h"
@@ -19,14 +20,11 @@ void _start(void) {
     pmm_init();
 
     init_serial();
-    log_to_serial("Hello, world!\n");
-
-    log_to_serial_digit(123);
 
     void *ptr = pmm_alloc(1);
-    kprintf("ptr: %p\n", ptr);
+    klog(0, "ptr: %p\n", ptr);
     void *ptr2 = pmm_alloc(1);
-    kprintf("ptr2: %p\n", ptr2);
+    klog(0, "ptr2: %p\n", ptr2);
 
     // uint8_t a = 1 / 0; // I can not belive the interrupt system works
 

--- a/src/kernel/startup.c
+++ b/src/kernel/startup.c
@@ -1,11 +1,11 @@
 #include "gdt.h"
 #include "idt.h"
 #include "keyboard.h"
-#include "pmm.h"
 #include "limine_term.h"
 #include "pic.h"
-#include "prompt.h"
+#include "pmm.h"
 #include "print.h"
+#include "prompt.h"
 #include "timer.h"
 #include <stdbool.h>
 // NOTE(Arman): *We can't use stdlib at all. We have to write our own functions*
@@ -18,25 +18,15 @@ void _start(void) {
     keyboard_init();
     pmm_init();
 
-    // testing hex output
-    // printf("%x\n", 1000000000);
-    // int x = 5;
-    // int *y = &x;
-    // printf("%p \n", y);
-    // // ------
-
-
-    // draw_line();
-
     init_serial();
     log_to_serial("Hello, world!\n");
 
     log_to_serial_digit(123);
 
-    void* ptr = pmm_alloc(1);
-    printf("ptr: %p\n", ptr);
-    void* ptr2 = pmm_alloc(1);
-    printf("ptr2: %p\n", ptr2);
+    void *ptr = pmm_alloc(1);
+    kprintf("ptr: %p\n", ptr);
+    void *ptr2 = pmm_alloc(1);
+    kprintf("ptr2: %p\n", ptr2);
 
     // uint8_t a = 1 / 0; // I can not belive the interrupt system works
 


### PR DESCRIPTION
1. extracted formatting logic used in printf to also use it in the logger.
2. renamed ```printf``` to ```kprintf``` and ```kernel_printf``` to ```vkprintf``` to avoid confusion with stdlib's ```printf```.
3. added logger which has similar logic to ```kpintf``` but instead of prompt, it will print to the terminal running qemu.
4. added development and production mode to makefile (```make``` or ```make prod```)